### PR TITLE
Add filtering of news articles without description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,6 @@
 
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-controls</artifactId>
-            <version>${javafx.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
             <version>${javafx.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,38 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
 
     <groupId>com.yourname</groupId>
     <artifactId>emotinews</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <javafx.version>20</javafx.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+        <javafx.version>21.0.1</javafx.version>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.13.1</version>
+        </dependency>
 
-        <!-- JSON parser -->
-    <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.13.1</version>
-    </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
+
     <build>
         <plugins>
-            <!-- Plugin do uruchamiania aplikacji -->
+            <!-- Do uruchamiania aplikacji -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <release>23</release>
+                </configuration>
+            </plugin>
+
+            <!-- Uruchamianie -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <configuration>
-                    <mainClass>main.java.com.majkel.emotinews.MainApp</mainClass>
+                    <mainClass>com.majkel.emotinews.ui.fxapp.FXMainApp</mainClass>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/majkel/emotinews/service/NewsFetcher.java
+++ b/src/main/java/com/majkel/emotinews/service/NewsFetcher.java
@@ -5,6 +5,7 @@ import com.majkel.emotinews.model.NewsHolder;
 import com.majkel.emotinews.config.ConfigLoader;
 import com.majkel.emotinews.exception.NewsApiException;
 import com.majkel.emotinews.model.NewsArticle;
+import com.majkel.emotinews.utils.CollectionUtils;
 
 import java.io.IOException;
 import java.net.URI;
@@ -22,7 +23,7 @@ public class NewsFetcher {
         List<NewsArticle> articles = null;
         try {
             HttpRequest getRequest = HttpRequest.newBuilder()
-                    .uri(new URI("https://newsapi.org/v2/"+query))
+                    .uri(new URI("https://newsapi.org/v2/"+query+"language=en"))
                     .header("X-Api-Key", ConfigLoader.getValue("api.news.key"))
                     .build();
             HttpResponse<String> getResponse=httpClient.send(getRequest, HttpResponse.BodyHandlers.ofString());
@@ -38,6 +39,8 @@ public class NewsFetcher {
         }catch (InterruptedException | IOException e){
             throw new NewsApiException("Error while calling NewsAPI",e);
         }
+        if(articles!=null)
+            articles= CollectionUtils.filterValidNews(articles);
         return articles!=null? articles:List.of();
     }
 }

--- a/src/main/java/com/majkel/emotinews/service/NewsPipeline.java
+++ b/src/main/java/com/majkel/emotinews/service/NewsPipeline.java
@@ -11,8 +11,10 @@ import java.util.List;
 public class NewsPipeline {
     public static List<NewsWithEmotions> loadNews(String tag){
         NewsFetcher newsFetcher=new NewsFetcher();
-        List<NewsArticle>articles = newsFetcher.getNewsList("top-headlines?q="+tag);
-        if(articles.size()>15) articles.subList(15,articles.size()).clear();
+        LocalDate localDate=LocalDate.now();
+        List<NewsArticle>articles = newsFetcher.getNewsList("everything?q="+tag+"&from="+localDate.minusDays(2)+"&sortBy=popularity");
+        System.out.println("everything?q="+tag+"&from="+localDate.minusDays(2)+"&sortBy=popularity");
+        if(articles.size()>20) articles.subList(20,articles.size()).clear();
         List<String>lSting= CollectionUtils.toStringList(articles);
 
         EmotionsAnalyzer emotionsAnalyzer=new EmotionsAnalyzer();
@@ -24,8 +26,8 @@ public class NewsPipeline {
 
     public static List<NewsWithEmotions> loadNews(){
         NewsFetcher newsFetcher=new NewsFetcher();
-        List<NewsArticle>articles = newsFetcher.getNewsList("everything?q=technology&from="+LocalDate.now().minusDays(2));
-        if(articles.size()>15) articles.subList(15,articles.size()).clear();
+        List<NewsArticle>articles = newsFetcher.getNewsList("everything?q=technology&from="+LocalDate.now().minusDays(4));
+        if(articles.size()>20) articles.subList(20,articles.size()).clear();
         List<String>lSting= CollectionUtils.toStringList(articles);
 
         EmotionsAnalyzer emotionsAnalyzer=new EmotionsAnalyzer();

--- a/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
+++ b/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
@@ -1,0 +1,62 @@
+package com.majkel.emotinews.ui.controller;
+
+import com.majkel.emotinews.model.NewsWithEmotions;
+import com.majkel.emotinews.service.NewsPipeline;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
+
+import java.util.List;
+
+public class MainViewController {
+    @FXML
+    private ListView<String> listViewObj;
+
+    private List<NewsWithEmotions> allNews;
+
+    @FXML
+    private TextField topicField;
+
+    @FXML
+    private void initialize(){
+        allNews = NewsPipeline.loadNews();
+        display(allNews);
+    }
+
+
+    private void display(List<NewsWithEmotions>news){
+        ObservableList<String>items= FXCollections.observableArrayList();
+        for(NewsWithEmotions n: news){
+            items.add(n.getArticle().getTitle());
+        }
+        listViewObj.setItems(items);
+    }
+
+    @FXML
+    public void handleAll(){
+        display(allNews);
+    }
+
+    @FXML
+    public void handlePositive(){
+        display(allNews.stream().filter(n->n.getEmotion().equals("LABEL_2")).toList());
+    }
+    @FXML
+    public void handleNegative(){
+        display(allNews.stream().filter(n->n.getEmotion().equals("LABEL_0")).toList());
+    }
+    @FXML
+    public void handleNeutral(){
+        display(allNews.stream().filter(n->n.getEmotion().equals("LABEL_1")).toList());
+    }
+    @FXML
+    public void searchTopic(){
+        if(topicField.getText().isEmpty())
+            return;
+        allNews=NewsPipeline.loadNews(topicField.getText());
+        display(allNews);
+        topicField.clear();
+    }
+}

--- a/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
+++ b/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
@@ -1,35 +1,88 @@
 package com.majkel.emotinews.ui.controller;
 
+import com.majkel.emotinews.model.NewsArticle;
 import com.majkel.emotinews.model.NewsWithEmotions;
 import com.majkel.emotinews.service.NewsPipeline;
+import javafx.application.HostServices;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
-import javafx.scene.control.ListView;
-import javafx.scene.control.TextField;
+import javafx.scene.control.*;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
 
 import java.util.List;
 
 public class MainViewController {
     @FXML
-    private ListView<String> listViewObj;
+    private ListView<NewsArticle> listViewObj;
 
     private List<NewsWithEmotions> allNews;
+
+    private HostServices hostServices;
+
+    private NewsArticle lastSelectedArticle;
 
     @FXML
     private TextField topicField;
 
     @FXML
+    private Hyperlink link;
+
+    @FXML
+    private Label title;
+
+    @FXML
+    private TextArea descryption;
+
+    @FXML
+    private VBox detailedBox;
+
+
+    @FXML
     private void initialize(){
         allNews = NewsPipeline.loadNews();
         display(allNews);
+
+        listViewObj.setCellFactory(param-> new ListCell<>(){
+                @Override
+                protected void updateItem(NewsArticle item,boolean empty){
+                    super.updateItem(item, empty);
+                    if(empty || item==null)
+                        setText(null);
+                    else
+                        setText(item.getTitle());
+            }
+        });
+
+        listViewObj.setOnMouseClicked(e->{
+            NewsArticle selected=listViewObj.getSelectionModel().getSelectedItem();
+            if(selected!=null)
+            {
+                if(selected==lastSelectedArticle){
+                    title.setText("");
+                    descryption.setText("");
+                    detailedBox.setVisible(false);
+                    detailedBox.setManaged(false);
+                    lastSelectedArticle=null;
+                }
+                else{
+                    detailedBox.setVisible(true);
+                    detailedBox.setManaged(true);
+                    title.setText(selected.getTitle());
+                    descryption.setText(selected.getDescription());
+                    link.setOnAction(event->hostServices.showDocument(selected.getUrl()));
+                    lastSelectedArticle=selected;
+                }
+            }
+        });
     }
 
 
     private void display(List<NewsWithEmotions>news){
-        ObservableList<String>items= FXCollections.observableArrayList();
+        ObservableList<NewsArticle>items= FXCollections.observableArrayList();
         for(NewsWithEmotions n: news){
-            items.add(n.getArticle().getTitle());
+            items.add(n.getArticle());
         }
         listViewObj.setItems(items);
     }
@@ -59,4 +112,9 @@ public class MainViewController {
         display(allNews);
         topicField.clear();
     }
+
+    public void setHostServices(HostServices hostServices){
+        this.hostServices=hostServices;
+    }
+
 }

--- a/src/main/java/com/majkel/emotinews/ui/fxapp/FXMainApp.java
+++ b/src/main/java/com/majkel/emotinews/ui/fxapp/FXMainApp.java
@@ -2,23 +2,21 @@ package com.majkel.emotinews.ui.fxapp;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
-import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import java.io.IOException;
 
-public class FXMainApp extends Application{
+public class FXMainApp extends Application {
     @Override
-    public void start(Stage stage) throws Exception{
-        FXMLLoader loader=new FXMLLoader(getClass().getResource("/view/MainView.fxml"));
-        Parent root=loader.load();
-        Scene scene=new Scene(root);
-
-        stage.setTitle("EmotiNews");
-        stage.setScene(scene);
-        stage.show();
+    public void start(Stage primaryStage) throws IOException {
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/majkel/emotinews/ui/view/MainView.fxml"));
+        Scene scene = new Scene(loader.load());
+        primaryStage.setTitle("EmotiNews");
+        primaryStage.setScene(scene);
+        primaryStage.show();
     }
 
-    public static void main(String[] args){
+    public static void main(String[] args) {
         launch(args);
     }
 }

--- a/src/main/java/com/majkel/emotinews/ui/fxapp/FXMainApp.java
+++ b/src/main/java/com/majkel/emotinews/ui/fxapp/FXMainApp.java
@@ -1,5 +1,6 @@
 package com.majkel.emotinews.ui.fxapp;
 
+import com.majkel.emotinews.ui.controller.MainViewController;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
@@ -11,6 +12,10 @@ public class FXMainApp extends Application {
     public void start(Stage primaryStage) throws IOException {
         FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/majkel/emotinews/ui/view/MainView.fxml"));
         Scene scene = new Scene(loader.load());
+
+        MainViewController controller = loader.getController();
+        controller.setHostServices(getHostServices());
+
         primaryStage.setTitle("EmotiNews");
         primaryStage.setScene(scene);
         primaryStage.show();

--- a/src/main/java/com/majkel/emotinews/ui/fxapp/FXMainApp.java
+++ b/src/main/java/com/majkel/emotinews/ui/fxapp/FXMainApp.java
@@ -1,0 +1,24 @@
+package com.majkel.emotinews.ui.fxapp;
+
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+public class FXMainApp extends Application{
+    @Override
+    public void start(Stage stage) throws Exception{
+        FXMLLoader loader=new FXMLLoader(getClass().getResource("/view/MainView.fxml"));
+        Parent root=loader.load();
+        Scene scene=new Scene(root);
+
+        stage.setTitle("EmotiNews");
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args){
+        launch(args);
+    }
+}

--- a/src/main/java/com/majkel/emotinews/ui/view/MainView.fxml
+++ b/src/main/java/com/majkel/emotinews/ui/view/MainView.fxml
@@ -1,0 +1,22 @@
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.control.TextField?>
+<VBox xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
+      fx:controller="com.majkel.emotinews.ui.controller.MainViewController"
+      spacing="11" alignment="TOP_CENTER" padding="20">
+    <HBox spacing="10" alignment="CENTER">
+            <Button text="All" onAction="#handleAll"/>
+            <Button text="Positive" onAction="#handlePositive"/>
+            <Button text="Negative" onAction="#handleNegative"/>
+            <Button text="Neutral" onAction="#handleNeutral"/>
+    </HBox>
+
+    <HBox spacing="10" alignment="CENTER">
+        <TextField fx:id="topicField" promptText="Enter topic..." prefWidth="300"/>
+        <Button text="Search" onAction="#searchTopic"/>
+    </HBox>
+
+    <ListView fx:id="listViewObj" prefHeight="600" prefWidth="400" VBox.vgrow="ALWAYS"/>
+</VBox>

--- a/src/main/java/com/majkel/emotinews/utils/CollectionUtils.java
+++ b/src/main/java/com/majkel/emotinews/utils/CollectionUtils.java
@@ -7,11 +7,13 @@ import com.majkel.emotinews.model.TextEmotion;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
+
 public class CollectionUtils {
     public static List<String> toStringList(List<NewsArticle> articles){
         List<String> result=new ArrayList<>();
         for(NewsArticle na: articles){
-            result.add(na.getDescription());
+            result.add(na.getDescription().trim());
         }
         return result;
     }
@@ -21,5 +23,14 @@ public class CollectionUtils {
             result.add(new NewsWithEmotions(emotions.get(i).getLabel(),articles.get(i)));
 
         return result;
+    }
+
+    private static boolean isValid(NewsArticle article){
+        if(article.getDescription()==null || article.getDescription().isBlank())
+            return false;
+        return true;
+    }
+    public static List<NewsArticle> filterValidNews(List<NewsArticle> articles){
+        return articles.stream().filter(CollectionUtils::isValid).toList();
     }
 }

--- a/src/main/resources/com/majkel/emotinews/ui/style/style.css
+++ b/src/main/resources/com/majkel/emotinews/ui/style/style.css
@@ -1,0 +1,59 @@
+/* style.css */
+
+.left-panel {
+    -fx-padding: 10;
+}
+
+.filter-box {
+    -fx-spacing: 10;
+}
+
+.filter-button {
+    -fx-background-color: #e0e0e0;
+    -fx-text-fill: #333;
+    -fx-font-weight: bold;
+}
+
+.search-button {
+    -fx-background-color: #1976d2;
+    -fx-text-fill: white;
+}
+
+.topic-field {
+    -fx-font-size: 14px;
+}
+
+.article-list {
+    -fx-background-color: white;
+    -fx-border-color: #ccc;
+    -fx-border-width: 1;
+}
+
+.details-box {
+    -fx-padding: 15;
+    -fx-spacing: 10;
+    -fx-background-color: #f9f9f9;
+    -fx-border-color: #ddd;
+    -fx-border-radius: 5;
+    -fx-background-radius: 5;
+    -fx-pref-width: 400;
+}
+
+.news-title {
+    -fx-font-size: 18px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #222;
+}
+
+.news-description {
+    -fx-font-size: 14px;
+    -fx-control-inner-background: #ffffff;
+    -fx-border-color: #ccc;
+    -fx-border-radius: 5;
+    -fx-padding: 8;
+}
+
+.news-link {
+    -fx-text-fill: #1a73e8;
+    -fx-underline: true;
+}

--- a/src/main/resources/com/majkel/emotinews/ui/style/style.css
+++ b/src/main/resources/com/majkel/emotinews/ui/style/style.css
@@ -39,21 +39,21 @@
     -fx-pref-width: 400;
 }
 
-.news-title {
-    -fx-font-size: 18px;
-    -fx-font-weight: bold;
-    -fx-text-fill: #222;
-}
-
 .news-description {
-    -fx-font-size: 14px;
-    -fx-control-inner-background: #ffffff;
-    -fx-border-color: #ccc;
-    -fx-border-radius: 5;
-    -fx-padding: 8;
+    -fx-font-size: 15px;
+    -fx-text-fill: #444;
+    -fx-padding: 8 10 10 10;
+    -fx-line-spacing: 4px;
+}
+.news-title {
+    -fx-font-size: 20px;
+    -fx-text-fill: #222;
 }
 
 .news-link {
     -fx-text-fill: #1a73e8;
     -fx-underline: true;
+}
+.list-cell:hover {
+    -fx-background-color: #e6e6e6;
 }

--- a/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
+++ b/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
@@ -1,35 +1,30 @@
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ListView?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextArea?>
-<?import javafx.scene.control.Hyperlink?>
+<?xml version="1.0" encoding="UTF-8"?>
 
-<HBox xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
-      fx:controller="com.majkel.emotinews.ui.controller.MainViewController"
-      spacing="11" alignment="TOP_LEFT" stylesheets="@../style/style.css" >
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 
-    <VBox spacing="11" alignment="TOP_CENTER" styleClass="left-panel">
-        <HBox spacing="10" alignment="CENTER" styleClass="filter-box">
-            <Button text="All" onAction="#handleAll" styleClass="filter-button"/>
-            <Button text="Positive" onAction="#handlePositive" styleClass="filter-button"/>
-            <Button text="Negative" onAction="#handleNegative" styleClass="filter-button"/>
-            <Button text="Neutral" onAction="#handleNeutral" styleClass="filter-button"/>
+<?import javafx.scene.text.Text?>
+<HBox alignment="TOP_LEFT" prefWidth="600" spacing="11" stylesheets="@../style/style.css" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.majkel.emotinews.ui.controller.MainViewController">
+
+    <VBox alignment="CENTER" spacing="11" styleClass="left-panel" HBox.hgrow="ALWAYS">
+        <HBox alignment="CENTER" spacing="10" styleClass="filter-box">
+            <Button onAction="#handleAll" styleClass="filter-button" text="All" />
+            <Button onAction="#handlePositive" styleClass="filter-button" text="Positive" />
+            <Button onAction="#handleNegative" styleClass="filter-button" text="Negative" />
+            <Button onAction="#handleNeutral" styleClass="filter-button" text="Neutral" />
         </HBox>
 
-        <HBox spacing="10" alignment="CENTER">
-            <TextField fx:id="topicField" promptText="Enter topic..." prefWidth="300" styleClass="topic-field"/>
-            <Button text="Search" onAction="#searchTopic" styleClass="search-button"/>
+        <HBox alignment="CENTER" spacing="10">
+            <TextField fx:id="topicField" prefWidth="300" promptText="Enter topic..." styleClass="topic-field" />
+            <Button onAction="#searchTopic" styleClass="search-button" text="Search" />
         </HBox>
 
-        <ListView fx:id="listViewObj" prefWidth="400" styleClass="article-list"/>
+        <ListView fx:id="listViewObj" prefWidth="400" styleClass="article-list" />
     </VBox>
 
-    <VBox fx:id="detailedBox" visible="false" managed="false" spacing="10" styleClass="details-box">
-        <Label fx:id="title" styleClass="news-title"/>
-        <TextArea fx:id="descryption" editable="false" wrapText="true" prefRowCount="10" styleClass="news-description"/>
-        <Hyperlink fx:id="link" text="Click to read more" styleClass="news-link"/>
+    <VBox fx:id="detailedBox" managed="false" spacing="10" styleClass="details-box" visible="false">
+        <Label fx:id="title" maxWidth="-Infinity" styleClass="news-title" wrapText="true" />
+        <Text fx:id="description" wrappingWidth="330" styleClass="news-description" />
+        <Hyperlink fx:id="link" styleClass="news-link" text="Click to read more" />
     </VBox>
 </HBox>

--- a/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
+++ b/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
@@ -3,37 +3,33 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.TextField?>
-
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.text.Text?>
-<?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.Hyperlink?>
+
 <HBox xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.majkel.emotinews.ui.controller.MainViewController"
-      spacing="11" alignment="TOP_LEFT" >
-    <VBox spacing="11" alignment="TOP_CENTER">
-        <HBox spacing="10" alignment="CENTER">
-            <Button text="All" onAction="#handleAll"/>
-            <Button text="Positive" onAction="#handlePositive"/>
-            <Button text="Negative" onAction="#handleNegative"/>
-            <Button text="Neutral" onAction="#handleNeutral"/>
+      spacing="11" alignment="TOP_LEFT" stylesheets="@../style/style.css" >
+
+    <VBox spacing="11" alignment="TOP_CENTER" styleClass="left-panel">
+        <HBox spacing="10" alignment="CENTER" styleClass="filter-box">
+            <Button text="All" onAction="#handleAll" styleClass="filter-button"/>
+            <Button text="Positive" onAction="#handlePositive" styleClass="filter-button"/>
+            <Button text="Negative" onAction="#handleNegative" styleClass="filter-button"/>
+            <Button text="Neutral" onAction="#handleNeutral" styleClass="filter-button"/>
         </HBox>
 
         <HBox spacing="10" alignment="CENTER">
-            <TextField fx:id="topicField" promptText="Enter topic..." prefWidth="300"/>
-            <Button text="Search" onAction="#searchTopic"/>
+            <TextField fx:id="topicField" promptText="Enter topic..." prefWidth="300" styleClass="topic-field"/>
+            <Button text="Search" onAction="#searchTopic" styleClass="search-button"/>
         </HBox>
 
-        <ListView fx:id="listViewObj" prefWidth="400" VBox.vgrow="ALWAYS"/>
+        <ListView fx:id="listViewObj" prefWidth="400" styleClass="article-list"/>
     </VBox>
-    <VBox fx:id="detailedBox" spacing="10" visible="false" managed="false" prefWidth="400">
-        <Label fx:id="title" style="-fx-font-size: 16px; -fx-font-weight: bold;" wrapText="true"/>
 
-        <!-- Lepsze wyświetlanie opisu: TextArea lub TextFlow -->
-        <TextArea fx:id="descryption" editable="false" wrapText="true"
-                  prefRowCount="10" prefWidth="380" maxWidth="Infinity"
-                  style="-fx-font-size: 14px;"/>
-
-        <Hyperlink fx:id="link" text="Click to read more"/>
+    <VBox fx:id="detailedBox" visible="false" managed="false" spacing="10" styleClass="details-box">
+        <Label fx:id="title" styleClass="news-title"/>
+        <TextArea fx:id="descryption" editable="false" wrapText="true" prefRowCount="10" styleClass="news-description"/>
+        <Hyperlink fx:id="link" text="Click to read more" styleClass="news-link"/>
     </VBox>
 </HBox>

--- a/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
+++ b/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
@@ -3,20 +3,37 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.TextField?>
-<VBox xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
+
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.control.Hyperlink?>
+<?import javafx.scene.control.TextArea?>
+<HBox xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.majkel.emotinews.ui.controller.MainViewController"
-      spacing="11" alignment="TOP_CENTER" >
-    <HBox spacing="10" alignment="CENTER">
-        <Button text="All" onAction="#handleAll"/>
-        <Button text="Positive" onAction="#handlePositive"/>
-        <Button text="Negative" onAction="#handleNegative"/>
-        <Button text="Neutral" onAction="#handleNeutral"/>
-    </HBox>
+      spacing="11" alignment="TOP_LEFT" >
+    <VBox spacing="11" alignment="TOP_CENTER">
+        <HBox spacing="10" alignment="CENTER">
+            <Button text="All" onAction="#handleAll"/>
+            <Button text="Positive" onAction="#handlePositive"/>
+            <Button text="Negative" onAction="#handleNegative"/>
+            <Button text="Neutral" onAction="#handleNeutral"/>
+        </HBox>
 
-    <HBox spacing="10" alignment="CENTER">
-        <TextField fx:id="topicField" promptText="Enter topic..." prefWidth="300"/>
-        <Button text="Search" onAction="#searchTopic"/>
-    </HBox>
+        <HBox spacing="10" alignment="CENTER">
+            <TextField fx:id="topicField" promptText="Enter topic..." prefWidth="300"/>
+            <Button text="Search" onAction="#searchTopic"/>
+        </HBox>
 
-    <ListView fx:id="listViewObj" prefWidth="400" VBox.vgrow="ALWAYS"/>
-</VBox>
+        <ListView fx:id="listViewObj" prefWidth="400" VBox.vgrow="ALWAYS"/>
+    </VBox>
+    <VBox fx:id="detailedBox" spacing="10" visible="false" managed="false" prefWidth="400">
+        <Label fx:id="title" style="-fx-font-size: 16px; -fx-font-weight: bold;" wrapText="true"/>
+
+        <!-- Lepsze wyświetlanie opisu: TextArea lub TextFlow -->
+        <TextArea fx:id="descryption" editable="false" wrapText="true"
+                  prefRowCount="10" prefWidth="380" maxWidth="Infinity"
+                  style="-fx-font-size: 14px;"/>
+
+        <Hyperlink fx:id="link" text="Click to read more"/>
+    </VBox>
+</HBox>

--- a/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
+++ b/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
@@ -5,12 +5,12 @@
 <?import javafx.scene.control.TextField?>
 <VBox xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.majkel.emotinews.ui.controller.MainViewController"
-      spacing="11" alignment="TOP_CENTER" padding="20">
+      spacing="11" alignment="TOP_CENTER" >
     <HBox spacing="10" alignment="CENTER">
-            <Button text="All" onAction="#handleAll"/>
-            <Button text="Positive" onAction="#handlePositive"/>
-            <Button text="Negative" onAction="#handleNegative"/>
-            <Button text="Neutral" onAction="#handleNeutral"/>
+        <Button text="All" onAction="#handleAll"/>
+        <Button text="Positive" onAction="#handlePositive"/>
+        <Button text="Negative" onAction="#handleNegative"/>
+        <Button text="Neutral" onAction="#handleNeutral"/>
     </HBox>
 
     <HBox spacing="10" alignment="CENTER">
@@ -18,5 +18,5 @@
         <Button text="Search" onAction="#searchTopic"/>
     </HBox>
 
-    <ListView fx:id="listViewObj" prefHeight="600" prefWidth="400" VBox.vgrow="ALWAYS"/>
+    <ListView fx:id="listViewObj" prefWidth="400" VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/src/main/resources/config.template.properties
+++ b/src/main/resources/config.template.properties
@@ -1,2 +1,3 @@
 #API
 api.news.key=
+api.huggingface.emotions.analizer=


### PR DESCRIPTION
This pull request introduces a method `filterValidNews(...)` in the `CollectionUtils` class
that filters out news articles with missing or blank descriptions.

This helps prevent incomplete or invalid news from being displayed in the UI.

Changes:
- Added filtering logic to `CollectionUtils`
- Applied the filter where news articles are pulled(in `NewsFeatcher`)

The change is self-contained and does not affect other parts of the application.