### PR TITLE
Added loading news to separate Thread in order to avoid UI lag

### DIFF
--- a/src/main/java/com/majkel/emotinews/model/NewsArticle.java
+++ b/src/main/java/com/majkel/emotinews/model/NewsArticle.java
@@ -39,6 +39,14 @@ public class NewsArticle{
         );
     }
 
+    public static NewsArticle createDefaultNews(){
+        return new NewsArticle(
+                "Waiting for news to load :D",
+                "After news load this news will be replaced"
+        );
+    }
+
+
 
     public String getPublishedAt() {
         return publishedAt;


### PR DESCRIPTION
## PR: Make News Fetching Asynchronous

### Description
This PR refactors the news fetching and analyzing process to run asynchronously using `Task` in JavaFX.  
Previously, fetching news blocked the JavaFX Application Thread, causing the UI to freeze during API calls.  
Now, the news pipeline runs in a background thread, ensuring the UI remains responsive.

### Changes
- Replaced synchronous calls to `NewsPipeline.loadNews(...)` with an asynchronous `Task`.
- Added `setOnSucceeded` and `setOnFailed` handlers to process results or errors safely on the JavaFX thread.
- Disabled the search button during execution and re-enabled it after task completion (together with cooldown).
- Improved error logging when background tasks fail.

### Benefits
- UI no longer freezes during news fetching.
- Users get a smoother experience while searching and analyzing news.
- Code is better prepared for adding progress indicators (spinner/progress bar) in a future feature branch.

### Next Steps (Future Work)
- Add a `ProgressIndicator` or spinner to provide visual feedback while news are being fetched.
- Improve error handling by showing messages in the UI instead of console logs.

---