### PR TITLE
Feature/news loading spinner

### DIFF
--- a/src/main/java/com/majkel/emotinews/MainApp.java
+++ b/src/main/java/com/majkel/emotinews/MainApp.java
@@ -1,5 +1,6 @@
 package com.majkel.emotinews;
 
+import com.majkel.emotinews.config.ConfigLoader;
 import com.majkel.emotinews.model.NewsWithEmotions;
 import com.majkel.emotinews.service.NewsPipeline;
 import com.majkel.emotinews.storage.JSONStorage;
@@ -36,7 +37,7 @@ public class MainApp {
             System.out.println("Git jest!!!");
 
          */
-        File file=new File("src/main/resources/news.json");
+        File file=new File(ConfigLoader.getValue("news.storage.path"));
         List<NewsWithEmotions>loadedList=List.of();
         try{
             loadedList=JSONStorage.load(file);

--- a/src/main/java/com/majkel/emotinews/model/NewsArticle.java
+++ b/src/main/java/com/majkel/emotinews/model/NewsArticle.java
@@ -39,6 +39,14 @@ public class NewsArticle{
         );
     }
 
+    public static NewsArticle createDefaultNews(){
+        return new NewsArticle(
+                "Waiting for news to load :D",
+                "After news load this news will be replaced"
+        );
+    }
+
+
 
     public String getPublishedAt() {
         return publishedAt;

--- a/src/main/java/com/majkel/emotinews/model/NewsArticle.java
+++ b/src/main/java/com/majkel/emotinews/model/NewsArticle.java
@@ -27,8 +27,15 @@ public class NewsArticle{
 
     public static NewsArticle createFallBackNews(){
         return new NewsArticle(
-                "Error: No Internet Connection",
+                "Error: Sentiment Analysis Unavailable",
                 "You are seeing this message because the app could not connect to the News API. Please check your internet connection and try again."
+        );
+    }
+
+    public static NewsArticle createAnalyzingNewsFallBackNews(){
+        return new NewsArticle(
+                "Error: Couldn't connect to",
+                "The app could not process the news sentiment using the HuggingFace model. Sometimes it could be overloaded, don't worry and please try again later."
         );
     }
 

--- a/src/main/java/com/majkel/emotinews/model/NewsArticle.java
+++ b/src/main/java/com/majkel/emotinews/model/NewsArticle.java
@@ -18,6 +18,20 @@ public class NewsArticle{
 
     private BooleanProperty favourite=new SimpleBooleanProperty(fav);
 
+    public NewsArticle(){}
+
+    public NewsArticle(String title, String description){
+        this.title=title;
+        this.description=description;
+    }
+
+    public static NewsArticle createFallBackNews(){
+        return new NewsArticle(
+                "Error: No Internet Connection",
+                "You are seeing this message because the app could not connect to the News API. Please check your internet connection and try again."
+        );
+    }
+
 
     public String getPublishedAt() {
         return publishedAt;

--- a/src/main/java/com/majkel/emotinews/model/NewsArticle.java
+++ b/src/main/java/com/majkel/emotinews/model/NewsArticle.java
@@ -25,16 +25,16 @@ public class NewsArticle{
         this.description=description;
     }
 
-    public static NewsArticle createFallBackNews(){
+    public static NewsArticle createFallBackNews(String errorMsg){
         return new NewsArticle(
-                "Error: Sentiment Analysis Unavailable",
+                "Error: "+errorMsg,
                 "You are seeing this message because the app could not connect to the News API. Please check your internet connection and try again."
         );
     }
 
-    public static NewsArticle createAnalyzingNewsFallBackNews(){
+    public static NewsArticle createAnalyzingNewsFallBackNews(String errorMsg){
         return new NewsArticle(
-                "Error: Couldn't connect to",
+                "Error: "+errorMsg,
                 "The app could not process the news sentiment using the HuggingFace model. Sometimes it could be overloaded, don't worry and please try again later."
         );
     }

--- a/src/main/java/com/majkel/emotinews/service/EmotionsAnalyzer.java
+++ b/src/main/java/com/majkel/emotinews/service/EmotionsAnalyzer.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.majkel.emotinews.config.ConfigLoader;
 import com.majkel.emotinews.exception.ParsingNewsApiException;
+import com.majkel.emotinews.model.NewsWithEmotions;
 import com.majkel.emotinews.model.TextEmotion;
 
 import java.io.IOException;
@@ -13,6 +14,8 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 
 public class EmotionsAnalyzer {
@@ -20,20 +23,34 @@ public class EmotionsAnalyzer {
     private final static HttpClient httpClient=HttpClient.newHttpClient();
 
     public List<TextEmotion> parseArticles(List<String> news){
+        System.out.println(news);
+        System.out.println("\n");
+        System.out.println(news.size());
+        try {
+            Thread.currentThread().sleep(10000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        if(news==null || news.isEmpty())
+            return new ArrayList<>();
         List<TextEmotion> emotionsList=null;
         Gson gson=new Gson();
-        //System.out.println("{\n"+"\"inputs\": "+gson.toJson(news)+"\n}");
         try{
             HttpRequest httpPost=HttpRequest.newBuilder()
                     .uri(new URI("https://api-inference.huggingface.co/models/cardiffnlp/twitter-roberta-base-sentiment"))
                     .POST(HttpRequest.BodyPublishers.ofString("{\n"+"\"inputs\": "+gson.toJson(news)+"\n}"))
                     .header("Authorization", ConfigLoader.getValue("api.huggingface.emotions.analizer"))
                     .header("Content-Type", "application/json")
+                    //.timeout(Duration.ofSeconds(45))
                     .build();
             HttpResponse<String> stringHttpResponse=httpClient.send(httpPost, HttpResponse.BodyHandlers.ofString());
 
             if(stringHttpResponse.statusCode()!=200)
                 throw new ParsingNewsApiException("Received status code "+ stringHttpResponse.statusCode());
+
+            if (stringHttpResponse.statusCode() == 429) {
+                throw new ParsingNewsApiException("Rate limit exceeded when calling HuggingFace API");
+            }
 
             Type type = new TypeToken<List<List<TextEmotion>>>(){}.getType();
             List<List<TextEmotion>> parsed = gson.fromJson(stringHttpResponse.body(), type);
@@ -41,10 +58,13 @@ public class EmotionsAnalyzer {
 
         }catch(URISyntaxException e){
             throw new RuntimeException("URISyntaxException ",e);
-        }catch (IOException | InterruptedException e){
-            throw new ParsingNewsApiException("Error while calling HuggingFaceAPI (news parser)",e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ParsingNewsApiException("Thread interrupted while calling HuggingFace API", e);
+        } catch (IOException e) {
+            throw new ParsingNewsApiException("I/O error while calling HuggingFace API", e);
         }
 
-        return emotionsList!=null?emotionsList:List.of();
+        return emotionsList!=null?emotionsList:new ArrayList<>();
     }
 }

--- a/src/main/java/com/majkel/emotinews/service/NewsFetcher.java
+++ b/src/main/java/com/majkel/emotinews/service/NewsFetcher.java
@@ -2,6 +2,7 @@ package com.majkel.emotinews.service;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.majkel.emotinews.adapter.BooleanPropertyAdapter;
 import com.majkel.emotinews.model.NewsHolder;
 import com.majkel.emotinews.config.ConfigLoader;
@@ -16,6 +17,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.ArrayList;
 import java.util.List;
 
 public class NewsFetcher {
@@ -35,15 +37,20 @@ public class NewsFetcher {
 
             NewsHolder response=gson.fromJson(getResponse.body(),NewsHolder.class);
             articles=response.getArticles();
-            System.out.println("Kod: "+response.getStatus());
 
         }catch(URISyntaxException e){
-            throw new RuntimeException("URISyntaxException ",e);
-        }catch (InterruptedException | IOException e){
-            throw new NewsApiException("Error while calling NewsAPI",e);
+            throw new NewsApiException("Invalid API URL", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new NewsApiException("Thread was interrupted while calling NewsAPI", e);
+        } catch (IOException e) {
+            throw new NewsApiException("I/O error while calling NewsAPI", e);
+        }catch(JsonSyntaxException e){
+            throw new NewsApiException("Invalid JSON received from NewsApi",e);
         }
-        if(articles!=null)
+
+        if(articles!=null && !articles.isEmpty())
             articles= CollectionUtils.filterValidNews(articles);
-        return articles!=null? articles:List.of();
+        return articles!=null?articles: new ArrayList<>();
     }
 }

--- a/src/main/java/com/majkel/emotinews/service/NewsPipeline.java
+++ b/src/main/java/com/majkel/emotinews/service/NewsPipeline.java
@@ -6,6 +6,7 @@ import com.majkel.emotinews.model.NewsWithEmotions;
 import com.majkel.emotinews.model.TextEmotion;
 import com.majkel.emotinews.utils.CollectionUtils;
 
+import java.net.http.HttpTimeoutException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,9 +32,16 @@ public class NewsPipeline {
 
         List<String>lSting= CollectionUtils.toStringList(articles);
 
+        List<NewsWithEmotions>newsWithEmotions=null;
+
         EmotionsAnalyzer emotionsAnalyzer=new EmotionsAnalyzer();
-        List<TextEmotion>emotions=emotionsAnalyzer.parseArticles(lSting);
-        List<NewsWithEmotions>newsWithEmotions=CollectionUtils.toNewsWithEmotionsList(articles,emotions);
+        try {
+            List<TextEmotion> emotions = emotionsAnalyzer.parseArticles(lSting);
+            newsWithEmotions=CollectionUtils.toNewsWithEmotionsList(articles,emotions);
+        } catch (HttpTimeoutException e) {
+            newsWithEmotions=new ArrayList<>();
+            newsWithEmotions.add(new NewsWithEmotions("LABEL_0",NewsArticle.createAnalyzingNewsFallBackNews()));
+        }
 
         return newsWithEmotions;
     }
@@ -58,9 +66,16 @@ public class NewsPipeline {
 
         List<String>lSting= CollectionUtils.toStringList(articles);
 
+        List<NewsWithEmotions>newsWithEmotions=null;
+
         EmotionsAnalyzer emotionsAnalyzer=new EmotionsAnalyzer();
-        List<TextEmotion>emotions=emotionsAnalyzer.parseArticles(lSting);
-        List<NewsWithEmotions>newsWithEmotions=CollectionUtils.toNewsWithEmotionsList(articles,emotions);
+        try {
+            List<TextEmotion> emotions = emotionsAnalyzer.parseArticles(lSting);
+            newsWithEmotions=CollectionUtils.toNewsWithEmotionsList(articles,emotions);
+        } catch (HttpTimeoutException e) {
+            newsWithEmotions=new ArrayList<>();
+            newsWithEmotions.add(new NewsWithEmotions("LABEL_0",NewsArticle.createAnalyzingNewsFallBackNews()));
+        }
 
         return newsWithEmotions;
     }

--- a/src/main/java/com/majkel/emotinews/service/NewsPipeline.java
+++ b/src/main/java/com/majkel/emotinews/service/NewsPipeline.java
@@ -1,20 +1,34 @@
 package com.majkel.emotinews.service;
 
+import com.majkel.emotinews.exception.NewsApiException;
 import com.majkel.emotinews.model.NewsArticle;
 import com.majkel.emotinews.model.NewsWithEmotions;
 import com.majkel.emotinews.model.TextEmotion;
 import com.majkel.emotinews.utils.CollectionUtils;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 public class NewsPipeline {
     public static List<NewsWithEmotions> loadNews(String tag){
         NewsFetcher newsFetcher=new NewsFetcher();
         LocalDate localDate=LocalDate.now();
-        List<NewsArticle>articles = newsFetcher.getNewsList("everything?q="+tag+"&from="+localDate.minusDays(2)+"&sortBy=popularity");
-        System.out.println("everything?q="+tag+"&from="+localDate.minusDays(2)+"&sortBy=popularity");
-        if(articles.size()>20) articles.subList(20,articles.size()).clear();
+        List<NewsArticle>articles=null;
+        try{
+            articles = newsFetcher.getNewsList("everything?q="+tag+"&from="+localDate.minusDays(2)+"&sortBy=popularity");
+        }catch (NewsApiException e){
+            List<NewsWithEmotions> list=new ArrayList<>();
+            list.add(new NewsWithEmotions("LABEL_0",NewsArticle.createFallBackNews()));
+            return list;
+        }
+
+        if(articles==null)
+            return new ArrayList<>();
+
+        if(articles.size()>20)
+            articles.subList(20,articles.size()).clear();
+
         List<String>lSting= CollectionUtils.toStringList(articles);
 
         EmotionsAnalyzer emotionsAnalyzer=new EmotionsAnalyzer();
@@ -26,8 +40,22 @@ public class NewsPipeline {
 
     public static List<NewsWithEmotions> loadNews(){
         NewsFetcher newsFetcher=new NewsFetcher();
-        List<NewsArticle>articles = newsFetcher.getNewsList("everything?q=technology&from="+LocalDate.now().minusDays(4));
-        if(articles.size()>20) articles.subList(20,articles.size()).clear();
+        List<NewsArticle>articles=null;
+
+        try{
+            articles = newsFetcher.getNewsList("everything?q=technology&from="+LocalDate.now().minusDays(4));
+        }catch (NewsApiException e){
+            List<NewsWithEmotions> list=new ArrayList<>();
+            list.add(new NewsWithEmotions("LABEL_0",NewsArticle.createFallBackNews()));
+            return list;
+        }
+
+        if(articles==null)
+            return new ArrayList<>();
+
+        if(articles.size()>20)
+            articles.subList(20,articles.size()).clear();
+
         List<String>lSting= CollectionUtils.toStringList(articles);
 
         EmotionsAnalyzer emotionsAnalyzer=new EmotionsAnalyzer();

--- a/src/main/java/com/majkel/emotinews/service/NewsPipeline.java
+++ b/src/main/java/com/majkel/emotinews/service/NewsPipeline.java
@@ -1,6 +1,7 @@
 package com.majkel.emotinews.service;
 
 import com.majkel.emotinews.exception.NewsApiException;
+import com.majkel.emotinews.exception.ParsingNewsApiException;
 import com.majkel.emotinews.model.NewsArticle;
 import com.majkel.emotinews.model.NewsWithEmotions;
 import com.majkel.emotinews.model.TextEmotion;
@@ -12,16 +13,29 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NewsPipeline {
-    public static List<NewsWithEmotions> loadNews(String tag){
+
+    private static List<NewsWithEmotions>load(boolean option,String tag){
         NewsFetcher newsFetcher=new NewsFetcher();
-        LocalDate localDate=LocalDate.now();
         List<NewsArticle>articles=null;
-        try{
-            articles = newsFetcher.getNewsList("everything?q="+tag+"&from="+localDate.minusDays(2)+"&sortBy=popularity");
-        }catch (NewsApiException e){
-            List<NewsWithEmotions> list=new ArrayList<>();
-            list.add(new NewsWithEmotions("LABEL_0",NewsArticle.createFallBackNews()));
-            return list;
+
+        if(option)//true and false to differ to "modes"
+        {
+            LocalDate localDate=LocalDate.now();
+            try{
+                articles = newsFetcher.getNewsList("everything?q="+tag+"&from="+localDate.minusDays(2)+"&sortBy=popularity");
+            }catch (NewsApiException e){
+                List<NewsWithEmotions> list=new ArrayList<>();
+                list.add(new NewsWithEmotions("LABEL_0",NewsArticle.createFallBackNews(e.getMessage())));
+                return list;
+            }
+        }else{
+            try{
+                articles = newsFetcher.getNewsList("everything?q=technology&from="+LocalDate.now().minusDays(4));
+            }catch (NewsApiException e){
+                List<NewsWithEmotions> list=new ArrayList<>();
+                list.add(new NewsWithEmotions("LABEL_0",NewsArticle.createFallBackNews(e.getMessage())));
+                return list;
+            }
         }
 
         if(articles==null)
@@ -38,46 +52,27 @@ public class NewsPipeline {
         try {
             List<TextEmotion> emotions = emotionsAnalyzer.parseArticles(lSting);
             newsWithEmotions=CollectionUtils.toNewsWithEmotionsList(articles,emotions);
-        } catch (HttpTimeoutException e) {
+        } catch (HttpTimeoutException e) { // added 3 catch that do the same in order be easier to overwrite in future
             newsWithEmotions=new ArrayList<>();
-            newsWithEmotions.add(new NewsWithEmotions("LABEL_0",NewsArticle.createAnalyzingNewsFallBackNews()));
+            newsWithEmotions.add(new NewsWithEmotions("LABEL_0",NewsArticle.createAnalyzingNewsFallBackNews("Request to HuggingFace timed out")));
+        } catch (ParsingNewsApiException e){
+            newsWithEmotions=new ArrayList<>();
+            newsWithEmotions.add(new NewsWithEmotions("LABEL_0",NewsArticle.createAnalyzingNewsFallBackNews(e.getMessage())));
+        } catch (Exception e) {
+            newsWithEmotions=new ArrayList<>();
+            newsWithEmotions.add(new NewsWithEmotions("LABEL_0",NewsArticle.createAnalyzingNewsFallBackNews(e.getMessage())));
         }
 
         return newsWithEmotions;
+
+    }
+
+    public static List<NewsWithEmotions> loadNews(String tag){
+        return load(true,tag);//true and false to differ to "modes"
     }
 
     public static List<NewsWithEmotions> loadNews(){
-        NewsFetcher newsFetcher=new NewsFetcher();
-        List<NewsArticle>articles=null;
-
-        try{
-            articles = newsFetcher.getNewsList("everything?q=technology&from="+LocalDate.now().minusDays(4));
-        }catch (NewsApiException e){
-            List<NewsWithEmotions> list=new ArrayList<>();
-            list.add(new NewsWithEmotions("LABEL_0",NewsArticle.createFallBackNews()));
-            return list;
-        }
-
-        if(articles==null)
-            return new ArrayList<>();
-
-        if(articles.size()>20)
-            articles.subList(20,articles.size()).clear();
-
-        List<String>lSting= CollectionUtils.toStringList(articles);
-
-        List<NewsWithEmotions>newsWithEmotions=null;
-
-        EmotionsAnalyzer emotionsAnalyzer=new EmotionsAnalyzer();
-        try {
-            List<TextEmotion> emotions = emotionsAnalyzer.parseArticles(lSting);
-            newsWithEmotions=CollectionUtils.toNewsWithEmotionsList(articles,emotions);
-        } catch (HttpTimeoutException e) {
-            newsWithEmotions=new ArrayList<>();
-            newsWithEmotions.add(new NewsWithEmotions("LABEL_0",NewsArticle.createAnalyzingNewsFallBackNews()));
-        }
-
-        return newsWithEmotions;
+        return load(false,"");//true and false to differ to "modes"
     }
 
 }

--- a/src/main/java/com/majkel/emotinews/storage/JSONStorage.java
+++ b/src/main/java/com/majkel/emotinews/storage/JSONStorage.java
@@ -2,6 +2,7 @@ package com.majkel.emotinews.storage;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.majkel.emotinews.adapter.BooleanPropertyAdapter;
 import com.majkel.emotinews.model.NewsWithEmotions;
@@ -30,15 +31,33 @@ public class JSONStorage {
         }
     }
 
-    public static List<NewsWithEmotions> load(File file) throws IOException{
-        if(!file.exists() || file.length()==0)
-            return new ArrayList<>();
-
-
-
-        try(FileReader fileReader=new FileReader(file)){
-            Type type=new TypeToken<List<NewsWithEmotions>>(){}.getType();
-            return gson.fromJson(fileReader,type);
+    public static void safeSave(File file,List<NewsWithEmotions> news){
+        try{
+            save(file,news);
+        } catch (IOException e) {
+            System.err.println("Error: Could not save favourites to file: " + file.getAbsolutePath());
         }
     }
+
+    public static List<NewsWithEmotions> load(File file) throws IOException{
+        try(FileReader fileReader=new FileReader(file)){
+            Type type=new TypeToken<List<NewsWithEmotions>>(){}.getType();
+            List<NewsWithEmotions>list= gson.fromJson(fileReader,type);
+            return list!=null?list:new ArrayList<>();
+        }
+    }
+
+    public static List<NewsWithEmotions> safeLoad(File file){
+        try{
+            return load(file);
+        } catch (IOException e) {
+            System.err.println("Error: Could not read file: " + file.getAbsolutePath());
+            return new ArrayList<>();
+        } catch (JsonSyntaxException e) {
+            System.err.println("Error: Invalid JSON format in file: " + file.getAbsolutePath());
+            return new ArrayList<>();
+        }
+    }
+
+
 }

--- a/src/main/java/com/majkel/emotinews/ui/controller/FavouritesController.java
+++ b/src/main/java/com/majkel/emotinews/ui/controller/FavouritesController.java
@@ -1,5 +1,6 @@
 package com.majkel.emotinews.ui.controller;
 
+import com.majkel.emotinews.config.ConfigLoader;
 import com.majkel.emotinews.model.NewsArticle;
 import com.majkel.emotinews.model.NewsWithEmotions;
 import com.majkel.emotinews.storage.JSONStorage;
@@ -15,13 +16,14 @@ import javafx.scene.text.Text;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.ObjectInputFilter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
 public class FavouritesController {
 
-    private final String storageFilePath="src/main/resources/news.json";
+    private final String storageFilePath= ConfigLoader.getValue("news.storage.path");
     private List<NewsWithEmotions>favAllList;
     private ObservableList<NewsWithEmotions>observableList;
 
@@ -48,11 +50,7 @@ public class FavouritesController {
 
     @FXML
     public void initialize(){
-        try{
-            favAllList= JSONStorage.load(new File(storageFilePath));
-        } catch (IOException e) {
-            System.out.println("ERROR: IOEXCEPTION in file (file path): "+storageFilePath);
-        }
+        favAllList=JSONStorage.safeLoad(new File(storageFilePath));
 
         Platform.runLater(()->{callbackFavList.accept(favAllList);});
 
@@ -167,10 +165,6 @@ public class FavouritesController {
         if(favAllList!=null)
             return favAllList;
         return new ArrayList<>();
-    }
-
-    public String getStorageFilePath() {
-        return storageFilePath;
     }
 
     public void setCallbackFavList(Consumer<List<NewsWithEmotions>>callbackFavList){

--- a/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
+++ b/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
@@ -50,6 +50,12 @@ public class MainViewController {
     @FXML
     private Button searchButton;
 
+    @FXML
+    private ProgressIndicator loadingSpinner;
+
+    @FXML
+    private Label loadingLabel;
+
     private String currentTopic="technology";//current topic, default=technology
 
     private Consumer<Callback> callbackConsumer;
@@ -73,16 +79,28 @@ public class MainViewController {
                 return NewsPipeline.loadNews();
             }
         };
+        loadingSpinner.visibleProperty().bind(task.runningProperty());
+        loadingSpinner.managedProperty().bind(task.runningProperty());
+        loadingLabel.visibleProperty().bind(task.runningProperty());
+        loadingLabel.managedProperty().bind(task.runningProperty());
         task.setOnSucceeded(e->{
             allNews=task.getValue();
             Platform.runLater(()->callbackConsumer.accept(new Callback(currentTopic,allNews)));
             syncFavouritesWithAllNews();
             display(allNews);
+            loadingSpinner.visibleProperty().unbind();
+            loadingSpinner.managedProperty().unbind();
+            loadingLabel.visibleProperty().unbind();
+            loadingLabel.managedProperty().unbind();
         });
         task.setOnFailed(e->{
             Throwable ex = task.getException();
             System.err.println("Failed at newsPipelineTask: " + ex.getMessage());
             ex.printStackTrace();
+            loadingSpinner.visibleProperty().unbind();
+            loadingSpinner.managedProperty().unbind();
+            loadingLabel.visibleProperty().unbind();
+            loadingLabel.managedProperty().unbind();
         });
         new Thread(task).start();
 
@@ -223,6 +241,13 @@ public class MainViewController {
                 return NewsPipeline.loadNews(topicField.getText());
             }
         };
+
+        loadingSpinner.visibleProperty().bind(newsPipelineTask.runningProperty());
+        loadingSpinner.managedProperty().bind(newsPipelineTask.runningProperty());
+        searchButton.disableProperty().bind(newsPipelineTask.runningProperty());
+        loadingLabel.visibleProperty().bind(newsPipelineTask.runningProperty());
+        loadingLabel.managedProperty().bind(newsPipelineTask.runningProperty());
+
         newsPipelineTask.setOnSucceeded(e->{
             allNews=newsPipelineTask.getValue();
             currentTopic=topicField.getText();
@@ -231,12 +256,22 @@ public class MainViewController {
             display(allNews);
             topicField.clear();
             newsPipelineTask=null;
+            loadingSpinner.visibleProperty().unbind();
+            loadingSpinner.managedProperty().unbind();
+            searchButton.disableProperty().unbind();
+            loadingLabel.visibleProperty().unbind();
+            loadingLabel.managedProperty().unbind();
         });
         newsPipelineTask.setOnFailed(e->{
             Throwable ex = newsPipelineTask.getException();
             System.err.println("Failed at newsPipelineTask: " + ex.getMessage());
             ex.printStackTrace();
             newsPipelineTask=null;
+            loadingSpinner.visibleProperty().unbind();
+            loadingSpinner.managedProperty().unbind();
+            searchButton.disableProperty().unbind();
+            loadingLabel.visibleProperty().unbind();
+            loadingLabel.managedProperty().unbind();
         });
         new Thread(newsPipelineTask).start();
     }

--- a/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
+++ b/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
@@ -56,6 +56,8 @@ public class MainViewController {
 
     private List<NewsWithEmotions> favourites=null;
 
+    //TODO url button anty null protection
+
     @FXML
     private void initialize(){
         allNews = NewsPipeline.loadNews();
@@ -125,7 +127,12 @@ public class MainViewController {
                     detailedBox.setManaged(true);
                     title.setText(selected.getArticle().getTitle());
                     description.setText(selected.getArticle().getDescription());
-                    link.setOnAction(event->hostServices.showDocument(selected.getArticle().getUrl()));
+                    String currentURL=selected.getArticle().getUrl();
+                    if(currentURL!=null && !currentURL.isEmpty())
+                        link.setOnAction(event->hostServices.showDocument(currentURL));
+                    else
+                        link.setVisible(false);
+
                     lastSelectedNews =selected;
                 }
             }

--- a/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
+++ b/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
@@ -56,7 +56,6 @@ public class MainViewController {
 
     private List<NewsWithEmotions> favourites=null;
 
-    //TODO url button anty null protection
 
     @FXML
     private void initialize(){

--- a/src/main/java/com/majkel/emotinews/ui/controller/RootController.java
+++ b/src/main/java/com/majkel/emotinews/ui/controller/RootController.java
@@ -36,12 +36,6 @@ public class RootController {
         return new ArrayList<>();
     }
 
-    public String getStorageFilePath(){
-        if(favouritesController!=null)
-            return favouritesController.getStorageFilePath();
-        return "";
-    }
-
 
     @FXML
     public void initialize() {

--- a/src/main/java/com/majkel/emotinews/ui/fxapp/FXMainApp.java
+++ b/src/main/java/com/majkel/emotinews/ui/fxapp/FXMainApp.java
@@ -1,5 +1,6 @@
 package com.majkel.emotinews.ui.fxapp;
 
+import com.majkel.emotinews.config.ConfigLoader;
 import com.majkel.emotinews.storage.JSONStorage;
 import com.majkel.emotinews.ui.controller.RootController;
 import javafx.application.Application;
@@ -23,11 +24,7 @@ public class FXMainApp extends Application {
         primaryStage.setScene(scene);
         primaryStage.show();
         primaryStage.setOnCloseRequest(e->{
-            try{
-                JSONStorage.save(new File(rootController.getStorageFilePath()),rootController.getFavouritesList());
-            } catch (IOException ex) {
-                throw new RuntimeException(ex);
-            }
+            JSONStorage.safeSave(new File(ConfigLoader.getValue("news.storage.path")),rootController.getFavouritesList());
         });
     }
 

--- a/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
+++ b/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
@@ -14,10 +14,17 @@
             <Button onAction="#handleNeutral" styleClass="filter-button" text="Neutral" />
         </HBox>
 
-        <HBox alignment="CENTER" spacing="10">
-            <TextField fx:id="topicField" prefWidth="300" promptText="Enter topic..." styleClass="topic-field" />
-            <Button fx:id="searchButton" onAction="#searchTopic" styleClass="search-button" text="Search" />
-        </HBox>
+        <StackPane>
+            <HBox alignment="CENTER" spacing="10">
+                <TextField fx:id="topicField" prefWidth="300" promptText="Enter topic..." styleClass="topic-field" />
+                <Button fx:id="searchButton" onAction="#searchTopic" styleClass="search-button" text="Search" />
+            </HBox>
+
+            <HBox  alignment="CENTER_LEFT" spacing="10">
+                <Label text="Loading news... " managed="false" visible="false" fx:id="loadingLabel"/>
+                <ProgressIndicator prefHeight="20" prefWidth="20" fx:id="loadingSpinner" visible="false" managed="false"/>
+            </HBox>
+        </StackPane>
         <ListView fx:id="listViewObj" prefWidth="400" styleClass="article-list" />
     </VBox>
 

--- a/src/main/resources/config.template.properties
+++ b/src/main/resources/config.template.properties
@@ -1,3 +1,6 @@
 #API
 api.news.key=
 api.huggingface.emotions.analizer=
+
+#Storage
+news.storage.path=src/main/resources/news.json

--- a/src/main/resources/news.json
+++ b/src/main/resources/news.json
@@ -49,5 +49,18 @@
       "fav": true,
       "favourite": true
     }
+  },
+  {
+    "emotion": "LABEL_1",
+    "article": {
+      "author": "Riley Gutiérrez McDermid",
+      "title": "Musk Stakes Tesla Future on One Major Gamble",
+      "description": "Will it become the next commonly adopted technology after EVs and smartphones?",
+      "url": "https://gizmodo.com/musk-optimus-robots-2000653481",
+      "publishedAt": "2025-09-04T14:40:08Z",
+      "content": "In a striking shift of narrative, Elon Musk has declared that Teslas future valuation will derive 80% from its Optimus humanoid robots, not its electric vehicle business.\r\nThis declaration, made in t… [+4149 chars]",
+      "fav": true,
+      "favourite": true
+    }
   }
 ]


### PR DESCRIPTION
## ✨ Add loading spinner during news fetch

### 📌 Summary
This PR adds a **loading spinner (ProgressIndicator)** next to the **Search** button.  
The spinner is shown while fetching and analyzing news asynchronously, and hidden once the task is finished or fails.

### ✅ Changes
- Added a `ProgressIndicator` to the FXML layout, positioned next to the **Search** button.
- Updated `MainViewController`:
  - Spinner becomes visible when a background task starts.
  - Spinner is hidden on task completion (`setOnSucceeded`) or failure (`setOnFailed`).
  - `setManaged(false)` is used when hidden, so it does not take extra layout space.
- Kept UI responsive while showing progress to the user.

### 🎯 Motivation
Previously, the UI gave no feedback while fetching news, which could confuse users (appearing as if the app froze).  
With this change, the spinner provides **clear visual feedback** that loading is in progress.

### 🚀 How to test
1. Start the app.  
2. Click **Search** with any topic.  
3. Verify:
   - Spinner appears immediately next to the Search button.
   - Spinner disappears once the news are loaded (or if the request fails).
   - UI remains responsive during loading.  