### PR TITLE
Added spinner and label to loading news

### DIFF
--- a/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
+++ b/src/main/java/com/majkel/emotinews/ui/controller/MainViewController.java
@@ -50,6 +50,12 @@ public class MainViewController {
     @FXML
     private Button searchButton;
 
+    @FXML
+    private ProgressIndicator loadingSpinner;
+
+    @FXML
+    private Label loadingLabel;
+
     private String currentTopic="technology";//current topic, default=technology
 
     private Consumer<Callback> callbackConsumer;
@@ -73,16 +79,28 @@ public class MainViewController {
                 return NewsPipeline.loadNews();
             }
         };
+        loadingSpinner.visibleProperty().bind(task.runningProperty());
+        loadingSpinner.managedProperty().bind(task.runningProperty());
+        loadingLabel.visibleProperty().bind(task.runningProperty());
+        loadingLabel.managedProperty().bind(task.runningProperty());
         task.setOnSucceeded(e->{
             allNews=task.getValue();
             Platform.runLater(()->callbackConsumer.accept(new Callback(currentTopic,allNews)));
             syncFavouritesWithAllNews();
             display(allNews);
+            loadingSpinner.visibleProperty().unbind();
+            loadingSpinner.managedProperty().unbind();
+            loadingLabel.visibleProperty().unbind();
+            loadingLabel.managedProperty().unbind();
         });
         task.setOnFailed(e->{
             Throwable ex = task.getException();
             System.err.println("Failed at newsPipelineTask: " + ex.getMessage());
             ex.printStackTrace();
+            loadingSpinner.visibleProperty().unbind();
+            loadingSpinner.managedProperty().unbind();
+            loadingLabel.visibleProperty().unbind();
+            loadingLabel.managedProperty().unbind();
         });
         new Thread(task).start();
 
@@ -223,6 +241,13 @@ public class MainViewController {
                 return NewsPipeline.loadNews(topicField.getText());
             }
         };
+
+        loadingSpinner.visibleProperty().bind(newsPipelineTask.runningProperty());
+        loadingSpinner.managedProperty().bind(newsPipelineTask.runningProperty());
+        searchButton.disableProperty().bind(newsPipelineTask.runningProperty());
+        loadingLabel.visibleProperty().bind(newsPipelineTask.runningProperty());
+        loadingLabel.managedProperty().bind(newsPipelineTask.runningProperty());
+
         newsPipelineTask.setOnSucceeded(e->{
             allNews=newsPipelineTask.getValue();
             currentTopic=topicField.getText();
@@ -231,12 +256,22 @@ public class MainViewController {
             display(allNews);
             topicField.clear();
             newsPipelineTask=null;
+            loadingSpinner.visibleProperty().unbind();
+            loadingSpinner.managedProperty().unbind();
+            searchButton.disableProperty().unbind();
+            loadingLabel.visibleProperty().unbind();
+            loadingLabel.managedProperty().unbind();
         });
         newsPipelineTask.setOnFailed(e->{
             Throwable ex = newsPipelineTask.getException();
             System.err.println("Failed at newsPipelineTask: " + ex.getMessage());
             ex.printStackTrace();
             newsPipelineTask=null;
+            loadingSpinner.visibleProperty().unbind();
+            loadingSpinner.managedProperty().unbind();
+            searchButton.disableProperty().unbind();
+            loadingLabel.visibleProperty().unbind();
+            loadingLabel.managedProperty().unbind();
         });
         new Thread(newsPipelineTask).start();
     }

--- a/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
+++ b/src/main/resources/com/majkel/emotinews/ui/view/MainView.fxml
@@ -14,10 +14,17 @@
             <Button onAction="#handleNeutral" styleClass="filter-button" text="Neutral" />
         </HBox>
 
-        <HBox alignment="CENTER" spacing="10">
-            <TextField fx:id="topicField" prefWidth="300" promptText="Enter topic..." styleClass="topic-field" />
-            <Button fx:id="searchButton" onAction="#searchTopic" styleClass="search-button" text="Search" />
-        </HBox>
+        <StackPane>
+            <HBox alignment="CENTER" spacing="10">
+                <TextField fx:id="topicField" prefWidth="300" promptText="Enter topic..." styleClass="topic-field" />
+                <Button fx:id="searchButton" onAction="#searchTopic" styleClass="search-button" text="Search" />
+            </HBox>
+
+            <HBox  alignment="CENTER_LEFT" spacing="10">
+                <Label text="Loading news... " managed="false" visible="false" fx:id="loadingLabel"/>
+                <ProgressIndicator prefHeight="20" prefWidth="20" fx:id="loadingSpinner" visible="false" managed="false"/>
+            </HBox>
+        </StackPane>
         <ListView fx:id="listViewObj" prefWidth="400" styleClass="article-list" />
     </VBox>
 


### PR DESCRIPTION
## ✨ Add loading spinner during news fetch

### 📌 Summary
This PR adds a **loading spinner (ProgressIndicator)** next to the **Search** button.  
The spinner is shown while fetching and analyzing news asynchronously, and hidden once the task is finished or fails.

### ✅ Changes
- Added a `ProgressIndicator` to the FXML layout, positioned next to the **Search** button.
- Updated `MainViewController`:
  - Spinner becomes visible when a background task starts.
  - Spinner is hidden on task completion (`setOnSucceeded`) or failure (`setOnFailed`).
  - `setManaged(false)` is used when hidden, so it does not take extra layout space.
- Kept UI responsive while showing progress to the user.

### 🎯 Motivation
Previously, the UI gave no feedback while fetching news, which could confuse users (appearing as if the app froze).  
With this change, the spinner provides **clear visual feedback** that loading is in progress.

### 🚀 How to test
1. Start the app.  
2. Click **Search** with any topic.  
3. Verify:
   - Spinner appears immediately next to the Search button.
   - Spinner disappears once the news are loaded (or if the request fails).
   - UI remains responsive during loading.  